### PR TITLE
фикс проверки типа enum для uriParameters

### DIFF
--- a/src/NamedParameter.php
+++ b/src/NamedParameter.php
@@ -844,7 +844,7 @@ class NamedParameter implements ArrayInstantiationInterface
         if ($this->validationPattern) {
             $pattern = $this->validationPattern;
         } elseif ($enum = $this->getEnum()) {
-            $pattern = '^(' . implode('\|', array_map('preg_quote', $enum)) . ')$';
+            $pattern = '^(' . implode('|', array_map('preg_quote', $enum)) . ')$';
         } else {
             switch ($this->getType()) {
                 case self::TYPE_NUMBER:

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -200,11 +200,11 @@ class Resource implements ArrayInstantiationInterface
             if ('^' === $matchPattern[0]) {
                 $matchPattern = substr($matchPattern, 1);
             }
-            
+
             if ('$' === substr($matchPattern, -1)) {
                 $matchPattern = substr($matchPattern, 0, -1);
             }
-            
+
             $regexUri = str_replace(
                 '/{'.$uriParameter->getKey().'}',
                 '/'.$matchPattern,
@@ -221,7 +221,8 @@ class Resource implements ArrayInstantiationInterface
 
         $regexUri = preg_replace('/\/{.*}/U', '\/([^/]+)', $regexUri);
         $regexUri = preg_replace('/\/~{.*}/U', '\/([^/]*)', $regexUri);
-        $regexUri =  '|^' . $regexUri . '$|';
+        // начало и конец регулярки - символ, который гарантированно не встретится
+        $regexUri = chr(128).'^'.$regexUri.'$'.chr(128);
 
         return (bool) preg_match($regexUri, $uri);
     }

--- a/test/NamedParameters/UriParameterTest.php
+++ b/test/NamedParameters/UriParameterTest.php
@@ -60,4 +60,26 @@ RAML;
         $resource = $apiDef->getResourceByUri('/user/alec');
         $this->assertInstanceOf('\Raml\Resource', $resource);
     }
+
+    /** @test */
+    public function shouldCorrectlyParseEnumUriParameters()
+    {
+        $raml = <<<RAML
+#%RAML 0.8
+title: User API
+version: 1.2
+/user:
+  /{userName}:
+    displayName: Get a user by name
+    uriParameters:
+      userName:
+        enum: [one, two]        
+    get:
+      displayName: retrieve a user's picture by user name
+RAML;
+
+        $apiDef = $this->parser->parseFromString($raml, '');
+        $resource = $apiDef->getResourceByUri('/user/one');
+        $this->assertInstanceOf('\Raml\Resource', $resource);
+    }
 }


### PR DESCRIPTION
Возможно баг в php, экранирование работает некорректно
```php
preg_match('|^(a\\|b)$|', 'a'); // false
preg_match('|^(a\|b)$|', 'a'); // false
preg_match('/^(a|b)$/', 'a'); // true
```