### PR TITLE
Фикс обработки required: false для объектов

### DIFF
--- a/src/Types/ObjectType.php
+++ b/src/Types/ObjectType.php
@@ -312,6 +312,9 @@ class ObjectType extends Type
                 }
                 continue;
             }
+            if ($propertyValue === null && !$property->getRequired()) {
+                continue;
+            }
             $property->validate($propertyValue);
             if (!$property->isValid()) {
                 $this->errors = array_merge($this->errors, $property->getErrors());

--- a/test/TypeTest.php
+++ b/test/TypeTest.php
@@ -42,6 +42,20 @@ class TypeTest extends PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function shouldCorrectlyValidateCorrectTypeNullUnrequired()
+    {
+        $simpleRaml = $this->parser->parse(__DIR__ . '/fixture/simple_types.raml');
+        $resource = $simpleRaml->getResourceByUri('/songs');
+        $method = $resource->getMethod('get');
+        $response = $method->getResponse(200);
+        $body = $response->getBodyByType('application/json');
+        $type = $body->getType();
+
+        $type->validate(json_decode('{"title":"Good Song", "artist":  null}', true));
+        self::assertTrue($type->isValid());
+    }
+
+    /** @test */
     public function shouldCorrectlyValidateCorrectTypeMissingRequired()
     {
 


### PR DESCRIPTION
types:
  Song:
    properties:
      title:
        type: string
        required: true
      artist:
        type: string
        required: false

В случае если в ответе artist = null, ответ не проходил валидацию