### PR TITLE
Прокидывание свойств UnionType во все его дочерние типы

### DIFF
--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -587,6 +587,7 @@ class ApiDefinition implements ArrayInstantiationInterface
             'boolean',
             'string',
             'null',
+            'nil',
             'file',
             'array',
             'object'

--- a/src/Types/NilType.php
+++ b/src/Types/NilType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Raml\Types;
+
+/**
+ * NilType class
+ * 
+ * @author Grigoriy Borozdin <g.borozdin@elama.ru>
+ */
+class NilType extends NullType
+{
+
+}

--- a/src/Types/UnionType.php
+++ b/src/Types/UnionType.php
@@ -21,17 +21,36 @@ class UnionType extends Type
     private $possibleTypes = [];
 
     /**
-    * Create a new UnionType from an array of data
-    *
-    * @param string    $name
-    * @param array     $data
-    *
-    * @return UnionType
-    */
+     * Create a new UnionType from an array of data
+     *
+     * @param string    $name
+     * @param array     $data
+     *
+     * @return UnionType
+     */
     public static function createFromArray($name, array $data = [])
     {
+        /**
+         * @var UnionType $type
+         */
         $type = parent::createFromArray($name, $data);
-        $type->setPossibleTypes(explode('|', $type->getType()));
+
+        $unionTypes = array_map(
+            function ($type) {
+                return trim($type);
+            },
+            explode('|', $type->getType())
+        );
+
+        $types = array_combine(
+            $unionTypes,
+            array_map(function ($type) use ($data) {
+                $data['type'] = $type;
+                return $data;
+            }, $unionTypes)
+        );
+
+        $type->setPossibleTypes($types);
         $type->setType('union');
 
         return $type;
@@ -56,8 +75,8 @@ class UnionType extends Type
      */
     public function setPossibleTypes(array $possibleTypes)
     {
-        foreach ($possibleTypes as $type) {
-            $this->possibleTypes[] = ApiDefinition::determineType(trim($type), ['type' => trim($type)]);
+        foreach ($possibleTypes as $type => $typeData) {
+            $this->possibleTypes[] = ApiDefinition::determineType($type, $typeData);
         }
 
         return $this;


### PR DESCRIPTION
Поддержка типа nil (https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#nil-type)

Прокидывание свойств UnionType во все его дочерние типы 
Парсер не криво отрабатывал на
при null значении, заваливалась валидация для type: string | nil